### PR TITLE
Fix warning "Implicitly marking parameter $data as nullable is deprecated"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require":{
-        "php": ">=5.3",
+        "php": ">=7.1",
         "ext-mbstring": "*"
     },
     "require-dev":{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab04fd70c56c9f63819d6c0828fa4695",
+    "content-hash": "6cf31b88d4f79165191b0f4e164fb023",
     "packages": [],
     "packages-dev": [
         {
@@ -1736,12 +1736,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3"
+        "php": ">=7.1",
+        "ext-mbstring": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/src/LucidFrame/Console/ConsoleTable.php
+++ b/src/LucidFrame/Console/ConsoleTable.php
@@ -78,7 +78,7 @@ class ConsoleTable
      * @param  array  $data The row data to add
      * @return object LucidFrame\Console\ConsoleTable
      */
-    public function addRow(array $data = null)
+    public function addRow(?array $data = null)
     {
         $this->rowIndex++;
 


### PR DESCRIPTION
Using php 8.4 a new warning comes up for method addRow().
**Deprecated**:  LucidFrame\Console\ConsoleTable::addRow(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead in **./ConsoleTable.php** on line **81**

See: 
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types